### PR TITLE
refactor(cache): decouple CacheService into dedicated CacheModule

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,9 +9,9 @@ import { TasksModule } from './modules/tasks/tasks.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { TaskProcessorModule } from './queues/task-processor/task-processor.module';
 import { ScheduledTasksModule } from './queues/scheduled-tasks/scheduled-tasks.module';
-import { CacheService } from './common/services/cache.service';
 import { HealthModule } from './health.module';
 import jwtConfig from '@config/jwt.config';
+import { CacheModule } from '@common/modules/cache.module';
 
 @Module({
   imports: [
@@ -20,7 +20,7 @@ import jwtConfig from '@config/jwt.config';
       isGlobal: true,
       load: [jwtConfig],
     }),
-    
+
     // Database
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
@@ -37,10 +37,10 @@ import jwtConfig from '@config/jwt.config';
         logging: configService.get('NODE_ENV') === 'development',
       }),
     }),
-    
+
     // Scheduling
     ScheduleModule.forRoot(),
-    
+
     // Queue
     BullModule.forRootAsync({
       imports: [ConfigModule],
@@ -52,38 +52,29 @@ import jwtConfig from '@config/jwt.config';
         },
       }),
     }),
-    
+
     // Rate limiting
     ThrottlerModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => ([
+      useFactory: (configService: ConfigService) => [
         {
           ttl: 60,
           limit: 10,
         },
-      ]),
+      ],
     }),
-    
+
     // Feature modules
     UsersModule,
     TasksModule,
     AuthModule,
-    
+
     // Queue processing modules
     TaskProcessorModule,
     ScheduledTasksModule,
     HealthModule,
+    CacheModule,
   ],
-  providers: [
-    // Inefficient: Global cache service with no configuration options
-    // This creates a single in-memory cache instance shared across all modules
-    CacheService
-  ],
-  exports: [
-    // Exporting the cache service makes it available to other modules
-    // but creates tight coupling
-    CacheService
-  ]
 })
-export class AppModule {} 
+export class AppModule {}

--- a/src/common/modules/cache.module.ts
+++ b/src/common/modules/cache.module.ts
@@ -1,0 +1,9 @@
+import { CacheService } from '@common/services/cache.service';
+import { Module, Global } from '@nestjs/common';
+
+@Global()
+@Module({
+  providers: [CacheService],
+  exports: [CacheService],
+})
+export class CacheModule {}


### PR DESCRIPTION
This PR refactors the existing CacheService setup by extracting it into a dedicated CacheModule to improve modularity and reduce tight coupling with the root AppModule.